### PR TITLE
Increase stack traversal depth to 1024 from 256

### DIFF
--- a/BepuPhysics/Trees/Tree_RayCast.cs
+++ b/BepuPhysics/Trees/Tree_RayCast.cs
@@ -87,7 +87,7 @@ namespace BepuPhysics.Trees
 
         }
 
-        internal const int TraversalStackCapacity = 256;
+        internal const int TraversalStackCapacity = 1024;
 
         internal readonly unsafe void RayCast<TLeafTester>(TreeRay* treeRay, RayData* rayData, ref TLeafTester leafTester) where TLeafTester : IRayLeafTester
         {


### PR DESCRIPTION
This is a stop gap solution to prevent some crashes from happening due to deeply nested colliders